### PR TITLE
Make configuration more hermetic, reduce reliability on dotfiles being ran from /home/$USER.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ sudo nix-store --optimise
 
 ### MacOS
 
+Install XCode manually as this cannot currently be automated
+
+then run these commands:
+sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer && sudo xcodebuild -runFirstLaunch
 #### Bootstrap
 To bootstrap nix on MacOS with my dotfiles, follow these steps:
 1. Clone the repository to ~/dotfiles

--- a/nix/home-manager/configs/zsh.nix
+++ b/nix/home-manager/configs/zsh.nix
@@ -19,9 +19,9 @@
     initExtra = ''
       export ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=#808080'
 
-      . $HOME/dotfiles/zsh/zshenv
-      . $HOME/dotfiles/zsh/zshfunctions
-      . $HOME/dotfiles/zsh/zshvim
+      . $HOME/.zsh/zshenv
+      . $HOME/.zsh/zshfunctions
+      . $HOME/.zsh/zshvim
 
       # adding important bin to bash
       export PATH=$PATH:$HOME/.scripts/bin

--- a/nix/hosts/macbook/configuration.nix
+++ b/nix/hosts/macbook/configuration.nix
@@ -215,7 +215,7 @@ in {
       "vlc"
       "whisky"
     ];
-    // mas install https://www.moncefbelyamani.com/how-to-install-xcode-with-homebrew/
+    # mas install https://www.moncefbelyamani.com/how-to-install-xcode-with-homebrew/
     masApps = {
         XCode = 497799835;
     };

--- a/nix/hosts/macbook/configuration.nix
+++ b/nix/hosts/macbook/configuration.nix
@@ -9,7 +9,7 @@ in {
 
   # List packages installed in system profile. To search by name, run:
   # $ nix-env -qaP | grep wget
-  environment.systemPackages = [pkgs.neovim pkgs.git];
+  environment.systemPackages = [pkgs.neovim pkgs.git pkgs.cocoapods];
 
   # Necessary for using flakes on this system.
   nix.settings.experimental-features = "nix-command flakes";
@@ -20,6 +20,7 @@ in {
   # Used for backwards compatibility, please read the changelog before changing.
   # $ darwin-rebuild changelog
   system.stateVersion = stateVersion;
+  ids.gids.nixbld = 350;
 
   # The platform the configuration will be used on.
   nixpkgs.hostPlatform = pkgs.stdenv.hostPlatform;
@@ -139,7 +140,7 @@ in {
       };
     };
     "com.googlecode.iterm2" = {
-      "PrefsCustomFolder" = "/Users/${username}/.config/iterm";
+      "PrefsCustomFolder" = "/Users/${userdata.username}/.config/iterm";
       "LoadPrefsFromCustomFolder" = 1;
     };
   };
@@ -174,23 +175,50 @@ in {
     brews = [
       "displayplacer"
       "libmagic"
+      "neovim"
+      "ruby"
     ];
 
     # `brew install --cask`
     casks = [
+      "flutter"
       "iterm2"
       "1password"
       "spotify"
       "alt-tab"
       "firefox"
+      "brave-browser"
       "signal"
       "messenger"
       "obsidian"
       "discord"
-      "monitorcontrol"
+      # Duy added this for his M1, I don't have a touchbar :) "monitorcontrol"
       "unnaturalscrollwheels"
       "rectangle"
+      "android-studio"
+      "android-platform-tools"
+      "caffeine"
+      "expressvpn"
+      "google-chrome"
+      "libreoffice"
+      "grandperspective"
+      "mactex"
+      "pycharm-ce"
+      "private-internet-access"
+      "qbittorrent"
+      "r"
+      "rstudio"
+      "steam"
+      "telegram"
+      "utm"
+      "visual-studio-code"
+      "vlc"
+      "whisky"
     ];
+    // mas install https://www.moncefbelyamani.com/how-to-install-xcode-with-homebrew/
+    masApps = {
+        XCode = 497799835;
+    };
     global.autoUpdate = true;
   };
   system.defaults.dock = {

--- a/nix/hosts/macbook/home.nix
+++ b/nix/hosts/macbook/home.nix
@@ -42,6 +42,9 @@ in {
     ".tmux.conf".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/dotfiles/utilities/tmux/.tmux.conf";
     "Library/Application Support/Code/User/settings.json".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/dotfiles/utilities/Code/settings.json";
     "Library/Application Support/Code/User/keybindings.json".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/dotfiles/utilities/Code/keybindings.json";
+    ".zsh/zshenv".source = "${project_root}/zsh/zshenv";
+    ".zsh/zshfunctions".source = "${project_root}/zsh/zshfunctions";
+    ".zsh/zshvim".source = "${project_root}/zsh/zshvim";
   };
 
   # Let Home Manager install and manage itself.

--- a/nix/hosts/nixos/home.nix
+++ b/nix/hosts/nixos/home.nix
@@ -82,15 +82,17 @@ in {
     # ".local/bin/nord_color_picker".source = "${project_root}/local/linux/.local/bin/nord_color_picker";
 
     ".config/starship.toml".source = "${project_root}/utilities/starship/starship.toml";
-    # TODO: Not hermetic, relying on dotfiles install at dotfiles
-    ".config/Code/User/settings.json".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/dotfiles/utilities/Code/settings.json";
-    ".config/Code/User/keybindings.json".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/dotfiles/utilities/Code/keybindings.json";
-    ".config/nvim".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/dotfiles/utilities/nvim";
+    ".config/Code/User/settings.json".source = "${project_root}/utilities/Code/settings.json";
+    ".config/Code/User/keybindings.json".source = "${project_root}/utilities/Code/keybindings.json";
+    ".config/nvim".source = "${project_root}/utilities/nvim";
 
     # Custom deskop files
     ".local/share/applications/uxplay.desktop".source = "${project_root}/utilities/desktops/uxplay.desktop";
     ".config/tmuxinator".source = "${project_root}/utilities/tmuxinator";
     ".tmux.conf".source = "${project_root}/utilities/tmux/.tmux.conf";
+    ".zsh/zshenv".source = "${project_root}/zsh/zshenv";
+    ".zsh/zshfunctions".source = "${project_root}/zsh/zshfunctions";
+    ".zsh/zshvim".source = "${project_root}/zsh/zshvim";
   };
 
   qt = {enable = true;};

--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -75,6 +75,6 @@ if [ "$os" = "Darwin" ]; then
   darwin-rebuild switch --flake ~/dotfiles#macbook-m1
 else
   echo "Detected non-macOS; running nix switch..."
-  sudo nixos-rebuild switch --cores 0 --flake ~/dotfiles#nixos
+  sudo nixos-rebuild switch --cores 0 --flake $git_root#nixos
 fi
 

--- a/userdata.nix
+++ b/userdata.nix
@@ -1,5 +1,5 @@
 {
-  username = "cunbidun";
-  email = "cunbidun@gmail.com";
-  name = "Duy Pham";
+  username = "john";
+  email = "johnpulford@gmail.com";
+  name = "John Pulford";
 }


### PR DESCRIPTION
Resulting files in home space are read only, update when original files are rewritten etc.

There are still some non-hermetic references to dotfiles throughout the repo, such as in mac/home.nix but I hesitant to update them until I have time to test mac specific updates. These updates were tested via UTM w/ Apple Virtualisation Framework.

When I tested this I ran dotfiles as root so we can be sure that the home files can be read even if the original location cannot be read by the user that requires them.