### PR TITLE
weather-sync fix so that python packages get picked up by new python …

### DIFF
--- a/nix/home-manager/scripts.nix
+++ b/nix/home-manager/scripts.nix
@@ -22,7 +22,7 @@
   weather-sync =
     pkgs.writers.writePython3Bin "weather-sync" {
       libraries = [
-        pkgs.python312Packages.requests
+        pkgs.python3Packages.requests
       ];
       flakeIgnore = [
         "E501" # Line too long


### PR DESCRIPTION
weather-sync is silently using a python dependency that would not fetch the previous python312 packages.

```
│   │   │   │   │   ├───/nix/store/gdjv8kx59df2yyxwhizk0dagrgfji2s1-weather-sync
│   │   │   │   │   │   └───/nix/store/k6yl3apwjq8g8ah0gs8n163kzfq1s7mw-python3-3.13.4-env
│   │   │   │   │   │       ├───/nix/store/q4wq65gl3r8fy746v9bbwgx4gzn0r2kl-glibc-2.40-66 [...]
│   │   │   │   │   │       ├───/nix/store/l7d6vwajpfvgsd3j4cr25imd1mzb7d1d-gcc-14.3.0-lib [...]
│   │   │   │   │   │       ├───/nix/store/sd81bvmch7njdpwx3lkjslixcbj5mivz-python3-3.13.4 [...]
│   │   │   │   │   │       └───/nix/store/k6yl3apwjq8g8ah0gs8n163kzfq1s7mw-python3-3.13.4-env [...]
```
